### PR TITLE
README updates for switch to mvp branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Tags help other people understand each issue! Here's some suggestions:
 - **Category Tags:** Examples: `OAuth`, `Form`.
 - `bug`: Something is broken, and not just because we haven't gotten there yet
 
-#### Suggested workflow
+#### Suggested workflow:
+(Example)
 **Kelsey** thinks it would be great if we had a dancing kitten on the front page. She makes an issue called "Dancing Kitten". She tags it "good-for-beginner", because it should be pretty simple, and  "help-wanted", because she doesn't have time to do it right now. She also links to a kitten gif, and adds a checklist:
 - [ ] Put kitten gif into static/images folder
 - [ ] Link to image on main page
@@ -50,49 +51,62 @@ Tags help other people understand each issue! Here's some suggestions:
 **Shadow** is looking for a fairly simple issue to get started on. They see "Dancing Kitten" and love the idea! They add a comment onto the issue:
 > Awesome idea! I'm working on it now :)
 
-Shadow gets everything set up on their machine, then makes a new branch for their work: `kitten-dance`. They work through the checklist, being sure to commit often and ask questions when they get stuck. When they're done, they make sure `kitten-dance ` is up to date with `static`, then push their **whole branch** up to the main repo (they don't merge it yet, because they want a code review first). Then Shadow makes a **pull request** and links it to the issue. Back in the issue, they add another comment and close the issue:
+Shadow gets everything set up on their machine, then makes a new branch for their work: `kitten-dance`. They work through the checklist, being sure to commit often and ask questions when they get stuck. When they're done, they make sure `kitten-dance ` is up to date with `mvp`, then push their **whole branch** up to the main repo (they don't merge it yet, because they want a code review first). Then Shadow makes a **pull request** and links it to the issue. Back in the issue, they add another comment and close the issue:
 > Finished! I made a pull request for branch 'kitten-dance' and would love a code review
 
 **Sydney** sees an open pull request, so she checks out their code. Everything looks good, she accepts the pull request, and *tada!* Now we have dancing kittens on the front page.
 
 ## How to Contribute:
-#### Set Up Local Repo
+#### Set Up a Local Repo
 You can either message Becka to be added as a contributor, or you can take the following steps:
 
 **Fork the Repo:** (there's a button in the upper right part of your screen)
 - This makes a copy of the repo on your github
 - It makes it so you can push up changes without needing to be an official/listed contributor
+- Your forked repo on github will be your remote "origin"
+- This is where you push your local work TO, and where you make pull requests FROM
 
 **Clone Your New Repo Copy:**
+- This is your local repo, where you make your changes
+- You will manage your changes and merge with updates from your upstream here (see next topic below)
+
 ```sh
 $ git clone https://github.com/[your-username-here]/ladynerds_site.git ladynerds_site
 $ cd ladynerds_site
 ```
 
+**Configure Your Remote Upstream
+- Set up your local repo to be able to fetch changes from the main beckastar/ladynerds repo on github
+- The beckastar/ladynerds repo on github will be your remote "upstream" 
+* Here's how to [configure your remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/)
+
+
 #### Keep Repos in Sync:
 **If you're not an official contributor:**
-You'll have to submit pull-requests from **your** github repo, rather than this one.
-Before you can make a pull request, pull and merge any updates from the orginal repo:
-* First, [configure your remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/)
-* Next, [get changes from the original repo](https://help.github.com/articles/syncing-a-fork/)
-    * (substitute "static" for "master" if your updates are in that branch)
-    * (changes to this README should be done in master)
-* Finally, [update YOUR github repo with your sync'ed and merged local changes](https://help.github.com/articles/pushing-to-a-remote/)
-* Now you can submit a pull request!
+You'll have to submit pull-requests from **your** github repo, rather than the original one.
 
-Keep in mind that if there are changes to both static and master, you will need to go through the fetch, merge, and push steps of this process in both branches
+Before you can make a pull request you need to:
+- Pull and merge any updates from the orginal "upstream" repo:
+    -[How to get changes from the original repo](https://help.github.com/articles/syncing-a-fork/)
+    -(substitute "mvp" for "master" if your updates are in that branch)
+- Push your merged changes up to your remote "origin" repo
+    -[How to update YOUR github repo with your sync'ed and merged local changes](https://help.github.com/articles/pushing-to-a-remote/)
+
+Keep in mind that if you've made changes to both mvp and master, you will need to go through the fetch, merge, and push steps of this process in both branches.
+
+Now you can submit a pull request!
 
 **If you are an official contributor:**
 - You have write access to the main repo. 
 - Make sure to make a new branch for your changes!
-- Update your branch with the static branch before submitting a pull request, so merging will be easier.
+- Update and merge your local branch with the mvp branch before submitting a pull request, so merging upstream will be easier.
 
 ```sh
 $ git branch
   master
-  static
+  mvp
 * my-branch
-$ git pull origin static
+$ git pull origin mvp
 $ git push origin my-branch
 ```
 
@@ -107,30 +121,31 @@ $ source env/bin/activate
 $ pip install -r requirements.txt
 ```
 
-**Checkout `static` branch:**
+**Checkout `mvp` branch:**
 
-This is where we're currently working. It's rough, I know. See what branches you have locally:
+This is where we're currently working (exception: changes to the README should be done in master)
+See what branches you have locally:
 ```sh
 $ git branch
 * master
-  static
+  mvp
 ```
 
-*If you only see master, get the static branch from your online repo:
+*If you only see master, get the mvp branch from your online repo:
 ```sh
-$ git checkout --track origin/static
+$ git checkout --track origin/mvp
 ```
 
-We're currently working on static, so check that out and make branches from there:
+We're currently working on mvp, so check that out and make branches from there:
 ```sh
-$ git checkout static
+$ git checkout mvp
 ```
 
 Now it should look like this when you 'git branch':
 ```sh
 $ git branch
   master
-* static
+* mvp
 ```
 
 **Run the web server:**
@@ -153,12 +168,8 @@ Check out the 'issues' tab (at the top of this repo) to find something you'd lik
 - If you do some work, submit a pull request/push up your branch and be sure to comment with whatever work you've done. 
 This will make it easier for other folks to help without duplicating code.
     - If you keep working, keep pushing! The pull request will keep updated.
-    - Make sure your pull request is comparing your local `issue` branch to the the original 
-    repos `static` branch.
-- It's very helpful to add the db.sqlite3 to your gitignore file while we're working without data 
+    - Make sure your pull request is comparing your local `issue` branch to the the original repos `mvp` branch.
 - If you're a contributor, please get a code review before accepting your own pull requests :)
-
-This is a screenshot of what you should see, currently (as of Feb 24, 2016), after you login. If it doesn't look like this, 
 
 The site currently has a black header with a black navbar, with neon green font. If you see something else, you're on the wrong branch. 
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 LadyNerds are an organization comprised of people who graduated from the Hackbright Academy coding bootcamp.  There are roughly 300 of us working in a variety of roles within the tech industry, primarily in San Francisco, but also places like Seattle, Portland, and New York. 
 
 ## Table of Contents
-- [About the Site](/ladynerds_site#about-the-site)
-- [Tracking Progress](/ladynerds_site#tracking-progress)
-    - [Making an Issue](/ladynerds_site#making-an-issue)
-    - [Tags](/ladynerds_site#tags)
-    - [Suggested Workflow](/ladynerds_site#suggested-workflow)
-- [How To Contribute](/ladynerds_site#how-to-contribute)
-    - [Set Up a Local Repo](/ladynerds_site#set-up-a-local-repo)
-    - [Keep Repos in Sync](/ladynerds_site#keep-repos-in-sync)
-    - [Choose An Issue](/ladynerds_site#choose-an-issue)
-- [Tips and Tricks](/ladynerds_site#tips-and-tricks)
+- [About the Site](#about-the-site)
+- [Tracking Progress](#tracking-progress)
+    - [Making an Issue](#making-an-issue)
+    - [Tags](#tags)
+    - [Suggested Workflow](#suggested-workflow)
+- [How To Contribute](#how-to-contribute)
+    - [Set Up a Local Repo](#set-up-a-local-repo)
+    - [Keep Repos in Sync](#keep-repos-in-sync)
+    - [Choose An Issue](#choose-an-issue)
+- [Tips and Tricks](#tips-and-tricks)
 
 ## About the Site
 This CRUD webapp is an ongoing collective project! Any LadyNerd is welcome to contribute. There are instructions for getting started below. Check out the 'issues' tab for things that need to be done.

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ You'll have to submit pull-requests from **your** github repo, rather than the o
 
 Before you can make a pull request you need to:
 - Pull and merge any updates from the orginal "upstream" repo:
-  *[How to get changes from the original repo](https://help.github.com/articles/syncing-a-fork/)
-  *(substitute "mvp" for "master" if your updates are in that branch)
+    - [How to get changes from the original repo](https://help.github.com/articles/syncing-a-fork/)
+    - (substitute "mvp" for "master" if your updates are in that branch)
 - Push your merged changes up to your remote "origin" repo
-  *[How to update YOUR github repo with your sync'ed and merged local changes](https://help.github.com/articles/pushing-to-a-remote/)
+    - [How to update YOUR github repo with your sync'ed and merged local changes](https://help.github.com/articles/pushing-to-a-remote/)
 
 Keep in mind that if you've made changes to both mvp and master, you will need to go through the fetch, merge, and push steps of this process in both branches.
 
@@ -162,13 +162,13 @@ Check out the 'issues' tab (at the top of this repo) to find something you'd lik
 ## Tips and Tricks:
 
 - Check out the 'issues' for features that we'd like to work on, or are already working on.
-  *IMPORTANT: Before you start working on your local repo, make a local branch for the issue
+    - IMPORTANT: Before you start working on your local repo, make a local branch for the issue
     you are working on.  Do all of your work for that issue on that branch.  This will make pull
     requests less confusing for everyone later on.
 - If you do some work, submit a pull request/push up your branch and be sure to comment with whatever work you've done. 
 This will make it easier for other folks to help without duplicating code.
-  *If you keep working, keep pushing! The pull request will keep updated.
-  *Make sure your pull request is comparing your local `issue` branch to the the original repos `mvp` branch.
+    - If you keep working, keep pushing! The pull request will keep updated.
+    - Make sure your pull request is comparing your local `issue` branch to the the original repos `mvp` branch.
 - If you're a contributor, please get a code review before accepting your own pull requests :)
 
 The site currently has a black header with a black navbar, with neon green font. If you see something else, you're on the wrong branch. 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ You'll have to submit pull-requests from **your** github repo, rather than the o
 
 Before you can make a pull request you need to:
 - Pull and merge any updates from the orginal "upstream" repo:
-    -[How to get changes from the original repo](https://help.github.com/articles/syncing-a-fork/)
-    -(substitute "mvp" for "master" if your updates are in that branch)
+  *[How to get changes from the original repo](https://help.github.com/articles/syncing-a-fork/)
+  *(substitute "mvp" for "master" if your updates are in that branch)
 - Push your merged changes up to your remote "origin" repo
-    -[How to update YOUR github repo with your sync'ed and merged local changes](https://help.github.com/articles/pushing-to-a-remote/)
+  *[How to update YOUR github repo with your sync'ed and merged local changes](https://help.github.com/articles/pushing-to-a-remote/)
 
 Keep in mind that if you've made changes to both mvp and master, you will need to go through the fetch, merge, and push steps of this process in both branches.
 
@@ -162,13 +162,13 @@ Check out the 'issues' tab (at the top of this repo) to find something you'd lik
 ## Tips and Tricks:
 
 - Check out the 'issues' for features that we'd like to work on, or are already working on.
-    - IMPORTANT: Before you start working on your local repo, make a local branch for the issue
+  *IMPORTANT: Before you start working on your local repo, make a local branch for the issue
     you are working on.  Do all of your work for that issue on that branch.  This will make pull
     requests less confusing for everyone later on.
 - If you do some work, submit a pull request/push up your branch and be sure to comment with whatever work you've done. 
 This will make it easier for other folks to help without duplicating code.
-    - If you keep working, keep pushing! The pull request will keep updated.
-    - Make sure your pull request is comparing your local `issue` branch to the the original repos `mvp` branch.
+  *If you keep working, keep pushing! The pull request will keep updated.
+  *Make sure your pull request is comparing your local `issue` branch to the the original repos `mvp` branch.
 - If you're a contributor, please get a code review before accepting your own pull requests :)
 
 The site currently has a black header with a black navbar, with neon green font. If you see something else, you're on the wrong branch. 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 LadyNerds are an organization comprised of people who graduated from the Hackbright Academy coding bootcamp.  There are roughly 300 of us working in a variety of roles within the tech industry, primarily in San Francisco, but also places like Seattle, Portland, and New York. 
 
 ## Table of Contents
-- [About the Site](https://github.com/beckastar/ladynerds_site#about-the-site)
-- [Tracking Progress](https://github.com/beckastar/ladynerds_site#tracking-progress)
-    - [Making an Issue](https://github.com/beckastar/ladynerds_site#making-an-issue)
-    - [Tags](https://github.com/beckastar/ladynerds_site#tags)
-    - [Suggested Workflow](https://github.com/beckastar/ladynerds_site#suggested-workflow)
-- [How To Contribute](https://github.com/beckastar/ladynerds_site#how-to-contribute)
-    - [Set Up a Local Repo](https://github.com/beckastar/ladynerds_site#set-up-a-local-repo)
-    - [Keep Repos in Sync](https://github.com/beckastar/ladynerds_site#keep-repos-in-sync)
-    - [Choose An Issue](https://github.com/beckastar/ladynerds_site#choose-an-issue)
-- [Tips and Tricks](https://github.com/beckastar/ladynerds_site#tips-and-tricks)
+- [About the Site](/ladynerds_site#about-the-site)
+- [Tracking Progress](/ladynerds_site#tracking-progress)
+    - [Making an Issue](/ladynerds_site#making-an-issue)
+    - [Tags](/ladynerds_site#tags)
+    - [Suggested Workflow](/ladynerds_site#suggested-workflow)
+- [How To Contribute](/ladynerds_site#how-to-contribute)
+    - [Set Up a Local Repo](/ladynerds_site#set-up-a-local-repo)
+    - [Keep Repos in Sync](/ladynerds_site#keep-repos-in-sync)
+    - [Choose An Issue](/ladynerds_site#choose-an-issue)
+- [Tips and Tricks](/ladynerds_site#tips-and-tricks)
 
 ## About the Site
 This CRUD webapp is an ongoing collective project! Any LadyNerd is welcome to contribute. There are instructions for getting started below. Check out the 'issues' tab for things that need to be done.


### PR DESCRIPTION
edited REAME for the following issues:
- edited doc to reflect switch from static to mvp branch
- made internal links relative (so reading from user's current repo doesn't redirect to beckastar repo)
-  re-organized the "fork workflow" instructions to clarify a few points
